### PR TITLE
chore: rename rule-transform to rules-transform

### DIFF
--- a/tests/trestlebot/cli/test_rules_transform_cmd.py
+++ b/tests/trestlebot/cli/test_rules_transform_cmd.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2024 Red Hat, Inc.
 
 
-"""Testing module for trestlebot rule-transform command"""
+"""Testing module for trestlebot rules-transform command"""
 
 import pathlib
 from typing import Tuple
@@ -11,14 +11,14 @@ from click.testing import CliRunner
 from git import Repo
 
 from tests.testutils import setup_for_compdef, setup_rules_view
-from trestlebot.cli.commands.rule_transform import rule_transform_cmd
+from trestlebot.cli.commands.rules_transform import rules_transform_cmd
 
 
 test_comp_name = "test_comp"
 test_md = "md_cd"
 
 
-def test_rule_transform(tmp_repo: Tuple[str, Repo]) -> None:
+def test_rules_transform(tmp_repo: Tuple[str, Repo]) -> None:
     """Test rule transform."""
     repo_path_str, repo = tmp_repo
 
@@ -31,7 +31,7 @@ def test_rule_transform(tmp_repo: Tuple[str, Repo]) -> None:
 
     runner = CliRunner()
     result = runner.invoke(
-        rule_transform_cmd,
+        rules_transform_cmd,
         [
             "--dry-run",
             "--repo-path",

--- a/trestlebot/cli/commands/rules_transform.py
+++ b/trestlebot/cli/commands/rules_transform.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2024 Red Hat, Inc.
 
-"""Module for rule-transform command"""
+"""Module for rules-transform command"""
 
 import logging
 from typing import Any, List
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 @click.command(
-    name="rule-transform",
+    name="rules-transform",
     help="Transform rules to an OSCAL Component Definition JSON file.",
 )
 @click.pass_context
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
     help="Comma-separated list of glob patterns for directories to skip when running tasks.",
 )
 @handle_exceptions
-def rule_transform_cmd(ctx: click.Context, **kwargs: Any) -> None:
+def rules_transform_cmd(ctx: click.Context, **kwargs: Any) -> None:
     """Run the rule transform operation."""
     # Allow any model to be skipped by setting skip_item, by default include all
     model_filter: ModelFilter = ModelFilter(

--- a/trestlebot/cli/root.py
+++ b/trestlebot/cli/root.py
@@ -9,7 +9,7 @@ import click
 from trestlebot.cli.commands.autosync import autosync_cmd
 from trestlebot.cli.commands.create import create_cmd
 from trestlebot.cli.commands.init import init_cmd
-from trestlebot.cli.commands.rule_transform import rule_transform_cmd
+from trestlebot.cli.commands.rules_transform import rules_transform_cmd
 from trestlebot.cli.commands.sync_upstreams import sync_upstreams_cmd
 
 
@@ -32,5 +32,5 @@ def root_cmd(ctx: click.Context) -> None:
 root_cmd.add_command(init_cmd)
 root_cmd.add_command(autosync_cmd)
 root_cmd.add_command(create_cmd)
-root_cmd.add_command(rule_transform_cmd)
+root_cmd.add_command(rules_transform_cmd)
 root_cmd.add_command(sync_upstreams_cmd)


### PR DESCRIPTION
## Description
Rename command rule-transform to rules-transform.


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
