### PR TITLE
ci: CPLYTM-821 - run release-please with an installation token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,6 @@ on:
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - name: Get Installation Token
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6


### PR DESCRIPTION
## Summary

`release-please` creates a PR bumping versions and drafting a changelog.
By default the PR is owned by github-actions and therefore CI tests from other workflows are not executed to prevent loop. This PR makes release-please to use a GH App token.

## Related Issues
CI tests are not executed when a PR is owned by `github-actions[bot]`
- https://github.com/complytime/trestle-bot/pull/574

This repository has required tests triggered by other workflows. Since these tests are not executed, the PR cannot be merged, ultimately impacting the release process.

## Review Hints

Here is the relevant documentation about "Triggering a workflow from a workflow":
- https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow

It is also mentioned in the release-please documentation:
- https://github.com/googleapis/release-please-action?tab=readme-ov-file#other-actions-on-release-please-prs

This simpler option would be to create a [PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) but this does not scale well, so a Github App using a limited [INSTALLATION TOKEN](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app) should work better.

The workflow was created based on [official documentation](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app) and inspired by the work from @huiwangredhat in https://github.com/complytime/cac-content/pull/26