### PR TITLE
fix: Update workflow sonar projectKey parameter due to rename

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -49,7 +49,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           args: >
-            -Dsonar.python.coverage.reportPaths=coverage.xml -Dsonar.tests=tests/ -Dsonar.sources=complyscribe/  -Dsonar.python.version=3.10 -Dsonar.projectKey=rh-psce_trestle-bot -Dsonar.organization=rh-psce
+            -Dsonar.python.coverage.reportPaths=coverage.xml -Dsonar.tests=tests/ -Dsonar.sources=complyscribe/  -Dsonar.python.version=3.10 -Dsonar.projectKey=rh-psce_complyscribe -Dsonar.organization=rh-psce
       - name: SonarQube Quality Gate check
         uses: sonarsource/sonarqube-quality-gate-action@df914238f99aa5d81f4490aeea80f205c7ed9600 # pin@f9fe214a5be5769c40619de2fff2726c36d2d5eb
         # Force to fail step after specific time


### PR DESCRIPTION
## Summary

Update workflow sonar projectKey parameter due to rename

## Review Hints

SonarCloud check running as expected.

