### PR TITLE
chore: CPLYTM-807 update sonarcloud project name

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=rh-psce_complyscribe
 sonar.organization=rh-psce
 
 # This is the name and version displayed in the SonarCloud UI.
-#sonar.projectName=trestle-bot
+sonar.projectName=complyscribe
 #sonar.projectVersion=1.0
 
 


### PR DESCRIPTION
## Summary
The PR updates the project name for SonarCloud.  It should update in the Sonar UI on the next analysis.