### PR TITLE
chore: update sonar project key in readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Pre commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![License](https://img.shields.io/badge/license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=rh-psce_trestle-bot&metric=coverage)](https://sonarcloud.io/summary/new_code?id=rh-psce_trestle-bot)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=rh-psce_trestle-bot&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=rh-psce_trestle-bot)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=rh-psce_complyscribe&metric=coverage)](https://sonarcloud.io/summary/new_code?id=rh-psce_complyscribe)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=rh-psce_complyscribe&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=rh-psce_complyscribe)
 
 
 ComplyScribe is a CLI tool that assists users in leveraging [Compliance-Trestle](https://github.com/oscal-compass/compliance-trestle) in CI/CD workflows for [OSCAL](https://github.com/usnistgov/OSCAL) formatted compliance content management.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,8 @@
 
 [![Pre commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![License](https://img.shields.io/badge/license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=rh-psce_trestle-bot&metric=coverage)](https://sonarcloud.io/summary/new_code?id=rh-psce_trestle-bot)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=rh-psce_trestle-bot&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=rh-psce_trestle-bot)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=rh-psce_complyscribe&metric=coverage)](https://sonarcloud.io/summary/new_code?id=rh-psce_complyscribe)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=rh-psce_complyscribe&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=rh-psce_complyscribe)
 
 
 


### PR DESCRIPTION
## Summary

This PR updates the README badges to point to the new SonarCloud project key.
