### PR TITLE
fix: CPLYTM-886 Not remove unselected rule when sync OSCAL to CaC content

### DIFF
--- a/complyscribe/utils.py
+++ b/complyscribe/utils.py
@@ -88,7 +88,12 @@ def write_cac_yaml_ordered(file_path: pathlib.Path, data: Any) -> None:
     Serializes a Python object into a CaC content YAML stream, preserving the order.
     """
     yaml = YAML()
+    # align with CaC content yaml file style
     yaml.indent(mapping=4, sequence=6, offset=4)
+    yaml.explicit_start = True
+    # temp workaround to mitigate line length difference
+    # between CaC yamlfix and complyscribe ruamel.yaml
+    yaml.width = 110
     yaml.dump(data, file_path)
 
 


### PR DESCRIPTION
## Summary

Not remove unselected rule when sync OSCAL to CaC content. Some CaC content `profile` files contains unselected rules(start with `!`, for example `!file_owner_at_allow`), now we do not remove them, and also not remove unselected rules from specific control in `control` files.

## Related Issues

- Closes CPLYTM-886

## Review Hints

- Generate OSCAL `catalog`, `profile` and `component definition` using `sync-cac-content` command. Pick a CaC profile contains unselected rules.
- Using 
```shell
poetry run complyscribe sync-oscal-content component-definition --dry-run --branch master --repo-path ~/trestlebot-workspace --committer-email axuan@redhat.com --committer-name axuan --cac-content-root ~/content --product rhel8 --oscal-profile cis_rhel8-l1_server
``` 
to sync OSCAL component-definition to CaC content. Then check the CaC content side change.
