### PR TITLE
fix: Load all controls from OSCAL catalog when sync OSCL CD to CaC

### DIFF
--- a/tests/complyscribe/cli/test_sync_oscal_content_cmd.py
+++ b/tests/complyscribe/cli/test_sync_oscal_content_cmd.py
@@ -58,6 +58,11 @@ def test_sync_oscal_cd_to_cac_control(
         test_product,
         model_name=os.path.join(test_product, test_profile_name),
     )
+    # rename profile dir name
+    os.rename(
+        os.path.join(trestle_repo_path, "profiles", test_profile_name),
+        os.path.join(trestle_repo_path, "profiles", f"{test_product}-{test_policy_id}"),
+    )
     tmp_content_dir = tmp_init_dir
     setup_for_cac_content_dir(tmp_content_dir, test_content_dir)
 
@@ -172,6 +177,11 @@ def test_sync_oscal_cd_statements(
         test_product,
         test_product,
         model_name=os.path.join(test_product, test_profile_name),
+    )
+    # rename profile dir name
+    os.rename(
+        os.path.join(trestle_repo_path, "profiles", test_profile_name),
+        os.path.join(trestle_repo_path, "profiles", f"{test_product}-{test_policy_id}"),
     )
     tmp_content_dir = tmp_init_dir
     setup_for_cac_content_dir(tmp_content_dir, test_content_dir)


### PR DESCRIPTION
## Summary

Load all controls from OSCAL catalog when sync Component Definition to CaC.

## Related Issues

None

## Review Hints

- Load all controls from OSCAL catalog when sync Component Definition to CaC. Prevent we can not get OSCAL control id and CaC control id mapping for controls removed from OSCAL profile.

## test 

- Generate OSCAL catalog, profile and component definition with CaC content `products/rhel8/profiles/cis_server_l1.profile` . 
- Remove one control(e.g. `reload_dconf_db`) from OSCAL profile(e.g. `profiles/rhel8-cis_rhel8-l1_server/profile.json` ).
- Modify some control in OSCAL component definition(e.g. `reload_dconf_db`).
- Run 
```shell
poetry run complyscribe sync-oscal-content component-definition --dry-run --repo-path ~/trestlebot-workspace --committer-email axuan@redhat.com --committer-name axuan --branch master --cac-content-root ~/content --product rhel8 --oscal-profile rhel8-cis_rhel8-l1_server
```

Sync OSCAL component definition to CaC.  
