### PR TITLE
fix: [CPLYTM-894] expend the benchmark root for ocp4

### DIFF
--- a/complyscribe/const.py
+++ b/complyscribe/const.py
@@ -63,3 +63,6 @@ COMPLYSCRIBE_KEEP_FILE = ".keep"
 # by the profile or catalog "name" based on trestle workspace
 # conventions.
 FRAMEWORK_SHORT_NAME = "Framework_Short_Name"
+
+# rule yml directory
+SAME_GUIDE_DIRECTORY = "../../linux_os/guide"

--- a/complyscribe/const.py
+++ b/complyscribe/const.py
@@ -65,4 +65,4 @@ COMPLYSCRIBE_KEEP_FILE = ".keep"
 FRAMEWORK_SHORT_NAME = "Framework_Short_Name"
 
 # rule yml directory
-SAME_GUIDE_DIRECTORY = "../../linux_os/guide"
+COMON_GUIDE_DIRECTORY = "../../linux_os/guide"

--- a/complyscribe/transformers/cac_transformer.py
+++ b/complyscribe/transformers/cac_transformer.py
@@ -5,7 +5,7 @@
 
 import logging
 import os
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from ssg.products import load_product_yaml, product_yaml_path
 from ssg.profiles import get_profiles_from_products
@@ -110,16 +110,17 @@ def add_prop(name: str, value: str, remarks: Optional[str] = None) -> Property:
     return prop
 
 
-def get_benchmark_root(root: str, product: str) -> List[Any]:
+def get_benchmark_root(root: str, product: str) -> Set[Any]:
     """Get the benchmark root."""
     product_yml_path = product_yaml_path(root, product)
     product_yaml = load_product_yaml(product_yml_path)
     product_dir = product_yaml.get("product_dir")
-    benchmark_root = []
-    benchmark_root.append(os.path.join(product_dir, product_yaml.get("benchmark_root")))
-    if product == "ocp4":
-        benchmark_root.append(os.path.join(product_dir, const.SAME_GUIDE_DIRECTORY))
-    return benchmark_root
+    benchmark_roots = set()
+    common_benchmark = os.path.join(product_dir, const.COMON_GUIDE_DIRECTORY)
+    product_benchmark = os.path.join(product_dir, product_yaml.get("benchmark_root"))
+    benchmark_roots.add(common_benchmark)
+    benchmark_roots.add(product_benchmark)
+    return benchmark_roots
 
 
 def get_profile_params(root: str, product: str, profile_id: str) -> Dict[str, Any]:
@@ -218,9 +219,9 @@ class RulesTransformer:
         self.root = root
         self.product = product
 
-        benchmark_root = get_benchmark_root(root, self.product)
+        benchmark_roots = get_benchmark_root(root, self.product)
         self.rules_dirs_for_product: Dict[str, str] = {}
-        for item in benchmark_root:
+        for item in benchmark_roots:
             for dir_path in find_rule_dirs_in_paths([item]):
                 rule_id = get_rule_dir_id(dir_path)
                 self.rules_dirs_for_product[rule_id] = dir_path

--- a/scripts/init_rh_products_content.sh
+++ b/scripts/init_rh_products_content.sh
@@ -51,9 +51,8 @@ for product in "${RH_PRODUCTS[@]}"; do
             map=${line//\'/\"}
             policy_id=$(echo "$map" | jq -r '.policy_id')
             profile=$(echo "$map" | jq -r '.profile_name')
-            levels_a=$(echo "$map" | jq -r '.levels[]')
-            IFS=' ' read -r -a levels <<< "$levels_a"
-            for level in "${levels[@]}"; do
+            echo "$map" | jq -r '.levels[]' > levels
+            while IFS= read -r level; do
                 oscal_profile=$product-$policy_id-$level
                 if [[ "$product" == *'rhel'* ]] ; then
                     type="software"
@@ -67,7 +66,7 @@ for product in "${RH_PRODUCTS[@]}"; do
                 poetry run complyscribe sync-cac-content component-definition --repo-path "$oscal_repo_path" --committer-email "openscap-ci@gmail.com" --committer-name "openscap-ci" --branch "$repo_branch" --cac-content-root "$cac_repo_path" --product "$product" --component-definition-type "$type" --cac-profile "$profile" --oscal-profile "$oscal_profile" --dry-run
                 type="validation"
                 poetry run complyscribe sync-cac-content component-definition --repo-path "$oscal_repo_path" --committer-email "openscap-ci@gmail.com" --committer-name "openscap-ci" --branch "$repo_branch" --cac-content-root "$cac_repo_path" --product "$product" --component-definition-type "$type" --cac-profile "$profile" --oscal-profile "$oscal_profile" --dry-run
-            done
+            done < levels
         done < "$product""_map.json"
     fi    
 done


### PR DESCRIPTION
## Summary
Some rules can't be loaded when I run the CLI sync-cac-content to transfer some OCP4 content to component-definition. The rules that can't be loaded are located in the same_guide_directory, `content/linux_os/guide`, not in the benchmark root `content/applications`.
This PR extends the benchmark root for ocp4 product to fix this error. 


- _Closes # [CPLYTM-882](https://issues.redhat.com/browse/CPLYTM-882)

## Review Hints
How to test:

- Make sure you have already generated the related catalog and profile

- Generate the component-definition
`poetry run complyscribe sync-cac-content component-definition --repo-path /Users/huiwang/issue-810/oscal-content --committer-email test@redhat.com --committer-name test --branch test_transfer_cli5 --cac-content-root /Users/huiwang/content --product ocp4 --branch research_ocp4 --component-definition-type service --cac-profile bsi-node-2022  --oscal-profile ocp4-bsi_sys_1_6-basic --dry-run`
