### PR TITLE
fix: Fix integration test failure

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,8 +1,8 @@
 # Integration Testing
 
-The purpose of the integration tests is to validate that complyscribe produces output that downstream utilities, like complytime, can consume.
+The purpose of the integration tests is to validate that complyscribe produces output that downstream utilities, like complyctl, can consume.
 
-The `complytime_home` fixture in `tests/integration/conftest.py` will download, cache, and install complytime to a temporary directory per test.
+The `complytime_home` fixture in `tests/integration/conftest.py` will download, cache, and install complyctl to a temporary directory per test.
 
-If integration tests fail, your cached complytime download may be stale; delete `/tmp/complyscribe-complytime-cache` and try again.
+If integration tests fail, your cached complyctl download may be stale; delete `/tmp/complyscribe-complytime-cache` and try again.
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -24,7 +24,7 @@ _TEST_PREFIX = "complyscribe_tests"
 T = TypeVar("T")
 YieldFixture = Generator[T, None, None]
 
-# Ask complytime to use home directory instead of hardcoded system paths
+# Ask complyctl to use home directory instead of hardcoded system paths
 os.putenv("COMPLYTIME_DEV_MODE", "1")
 
 
@@ -47,7 +47,7 @@ def is_complytime_installed(install_dir: Path) -> bool:
 def is_complytime_cached(download_dir: Path) -> bool:
     return bool(
         glob.glob(
-            str((download_dir / "releases/*/complytime_linux_x86_64.tar.gz").resolve())
+            str((download_dir / "releases/*/complyctl_linux_x86_64.tar.gz").resolve())
         )
     )
 
@@ -80,7 +80,7 @@ def complytime_home() -> YieldFixture[Path]:
             result = subprocess.run(
                 [
                     scripts_dir / "get-github-release.py",
-                    "https://github.com/complytime/complytime",
+                    "https://github.com/complytime/complyctl",
                 ],
                 cwd=complytime_cache_dir,
                 capture_output=True,
@@ -97,7 +97,7 @@ def complytime_home() -> YieldFixture[Path]:
                 "find",
                 f"{complytime_cache_dir}/releases",
                 "-name",
-                "complytime_linux_x86_64.tar.gz",
+                "complyctl_linux_x86_64.tar.gz",
                 "-exec",
                 "tar",
                 "-xvf",
@@ -114,7 +114,7 @@ def complytime_home() -> YieldFixture[Path]:
                 f"Unable to extract ComplyTime for integration test!\n{result.stdout}\n{result.stderr}"
             )
 
-        # Install complytime
+        # Install complyctl
         install_complytime(complytime_home)
 
         # Create dummy base files
@@ -170,7 +170,7 @@ def install_complytime(complytime_home: Path) -> None:
     Path(complytime_home / ".local/share/complytime/controls/").mkdir(
         parents=True, exist_ok=True
     )
-    shutil.move(complytime_home / "complytime", complytime_home / "bin/complytime")
+    shutil.move(complytime_home / "complyctl", complytime_home / "bin/complyctl")
     shutil.move(
         complytime_home / "openscap-plugin",
         complytime_home / ".local/share/complytime/plugins/openscap-plugin",

--- a/tests/integration/test_int.py
+++ b/tests/integration/test_int.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2025 Red Hat, Inc.
 
 """
-Integration tests for validating that complyscribe output is consumable by complytime
+Integration tests for validating that complyscribe output is consumable by complyctl
 """
 import json
 import logging
@@ -28,7 +28,7 @@ logger.setLevel(logging.INFO)
 
 test_content_dir = TEST_DATA_DIR / "content_dir"
 
-# Ask complytime to use home directory instead of hardcoded system paths
+# Ask complyctl to use home directory instead of hardcoded system paths
 os.putenv("COMPLYTIME_DEV_MODE", "1")
 
 
@@ -37,7 +37,7 @@ os.putenv("COMPLYTIME_DEV_MODE", "1")
 def test_complytime_setup() -> None:
     """Ensure that the complytime integration test setup works"""
     result = subprocess.run(
-        ["complytime", "list", "--plain"],
+        ["complyctl", "list", "--plain"],
         capture_output=True,
     )
     assert result.returncode == 0
@@ -142,7 +142,7 @@ def test_full_sync(tmp_repo: Tuple[str, Repo], complytime_home: pathlib.Path) ->
     )
     new_prof_json_text = new_prof_json_text.replace(
         '"param_id"', '"param-id"'
-    )  # TODO compliance-trestle uses param_id and param-id interchangably, complytime requires param-id
+    )  # TODO compliance-trestle uses param_id and param-id interchangably, complyctl requires param-id
     new_prof_json = json.loads(new_prof_json_text)
 
     new_cd_json_text = component_definition.read_text()
@@ -167,7 +167,7 @@ def test_full_sync(tmp_repo: Tuple[str, Repo], complytime_home: pathlib.Path) ->
         json.dump(new_cd_json, file)
 
     result = subprocess.run(
-        ["complytime", "list", "--plain"],
+        ["complyctl", "list", "--plain"],
         capture_output=True,
     )
     assert result.returncode == 0
@@ -303,7 +303,7 @@ def test_compdef_type_software_sync(
         json.dump(new_cd_json, file)
 
     result = subprocess.run(
-        ["complytime", "list", "--plain"],
+        ["complyctl", "list", "--plain"],
         capture_output=True,
     )
     assert result.returncode == 0
@@ -439,7 +439,7 @@ def test_compdef_type_validation_sync(
         json.dump(new_cd_json, file)
 
     result = subprocess.run(
-        ["complytime", "list", "--plain"],
+        ["complyctl", "list", "--plain"],
         capture_output=True,
     )
     assert result.returncode == 0


### PR DESCRIPTION
## Summary

Due to `complytime` executable rename to `complyctl`, integration test failed. Rename `complytime` to `complyctl` for integration test.

## Related Issues

None

## Review Hints

- Rename complytime to complyctl for integration test
