### PR TITLE
fix: [CPLYTM-910] fix error in ospp transfer

### DIFF
--- a/complyscribe/transformers/cac_transformer.py
+++ b/complyscribe/transformers/cac_transformer.py
@@ -242,8 +242,9 @@ class RulesTransformer:
             selected_value = param_data[self.product][self.profile_id]
             param_obj.set_selected_value(selected_value)
             options = get_variable_options(root, param_id)
-            param_obj.set_options(options)
-            rule_obj.add_parameter(param_obj)
+            if options:
+                param_obj.set_options(options)
+                rule_obj.add_parameter(param_obj)
 
     def add_rules(self, rules: List[str]) -> None:
         """


### PR DESCRIPTION
## Summary
Fix the [error](https://issues.redhat.com/browse/CPLYTM-910)  in ospp transfer. This occurs because the `ssg.get_variable_options(root, param_id)` function returns an empty dictionary `{}` for the `options` variable.
This happens when the function cannot find certain [variables](https://github.com/ComplianceAsCode/content/blob/master/controls/ospp.yml#L52) within the [control file ](https://github.com/ComplianceAsCode/content/blob/master/controls/ospp.yml).
In short, these special properties are not used since the profiles consuming OSPP control file are removing these rules anyways. We will update the control file and respective profiles from CAC side.
The updates of the PR in `complyscribe` could skip the special ones.


- _Closes #CPLYTM-910_

## Review Hints
Run the transfer CLI, it could transfer the control file to oscal component-definition with no error.
- `poetry run complyscribe sync-cac-content component-definition --repo-path /Users/huiwang/issue-810/oscal-content --committer-email "openscap-ci@gmail.com" --committer-name "openscap-ci" --branch test_rhel8 --cac-content-root /Users/huiwang/content --product rhel8 --component-definition-type software --cac-profile ospp --oscal-profile rhel8-ospp-base --dry-run`

