### PR TITLE
docs: CPLYTM-896 Update documentations

### DIFF
--- a/docs/tutorials/sync-cac-content.md
+++ b/docs/tutorials/sync-cac-content.md
@@ -1,11 +1,97 @@
 # The complyscribe command line sync-cac-content Tutorial
 
-This tutorial provides how to use `complyscribe sync-cac-content` transform [Cac content](https://github.com/ComplianceAsCode/content) to OSCAL models.
-This command has two sub-commands `component-definition` and `profile`
+This tutorial provides how to use `complyscribe sync-cac-content` transform [cac-content](https://github.com/ComplianceAsCode/content) to OSCAL models.
+This command has three sub-commands `catalog`, `profile` and `component-definition`
+
+> **WARNING:** There is a sequential order when transformed, first Catalog, then Profile, last Component Definition.
+> Because Profile depends on Catalog, and Component Definition depends on Profile.
+
+## catalog
+
+This command is to generate OSCAL Catalog according to CaC content policy 
+
+### 1. Prerequisites
+
+- Initialize the [complyscribe workspace](../tutorials/github.md#3-initialize-complyscribe-workspace) if you do not have one.
+
+- Clone the [cac-content repository](https://github.com/ComplianceAsCode/content).
+
+### 2. Run the CLI sync-cac-content catalog
+
+A real world example, if we want to transform [cis_rhel8](https://github.com/ComplianceAsCode/content/blob/master/controls/cis_rhel8.yml)
+to OSCAL Catalog, we run command like below,`cac-policy-id` is [control file id](https://github.com/ComplianceAsCode/content/blob/master/controls/cis_rhel8.yml#L4),
+`oscal-catalog` is OSCAL Catalog directory name we will use when generating the OSCAL Catalog.
+
+```shell
+poetry run complyscribe sync-cac-content catalog \
+--dry-run \
+--repo-path $complyscribe_workspace_root_dir \
+--committer-email tester@redhat.com \
+--committer-name tester \
+--branch main \
+--cac-policy-id cis_rhel8 \
+--oscal-catalog cis_rhel8 \
+--cac-content-root $cac_content_root_dir
+```
+
+After successfully running above command, will generate [catalogs/cis_rhel8/catalog.json](https://github.com/ComplianceAsCode/oscal-content/blob/main/catalogs/cis_rhel8/catalog.json)
+
+For more details about these options and additional flags, you can use the `--help` flag:
+`poetry run complyscribe sync-cac-content catalog --help`
+This will display a full list of available options and their descriptions.
+
+After running the CLI with the right options, you would successfully generate an OSCAL Catalog under
+`$complyscribe_workspace_root_dir/catalogs`.
+
+
+## profile
+
+This command is to generate OSCAL Profile according to content policy 
+
+### 1. Prerequisites
+
+- Initialize the [complyscribe workspace](../tutorials/github.md#3-initialize-complyscribe-workspace) if you do not have one.
+
+- Clone the [cac-content repository](https://github.com/ComplianceAsCode/content).
+
+### 2. Run the CLI sync-cac-content profile
+
+A real world example, if we want to transform [rhel8 product](https://github.com/ComplianceAsCode/content/tree/master/products/rhel8)
+that using [cis_rhel8 control file](https://github.com/ComplianceAsCode/content/blob/master/controls/cis_rhel8.yml) to OSCAL Profile,
+we run command like below, `product` is [product name](https://github.com/ComplianceAsCode/content/blob/master/products/rhel8/product.yml#L1), 
+`oscal-catalog` is OSCAL [catalog directory name](https://github.com/ComplianceAsCode/oscal-content/tree/main/catalogs/cis_rhel8),
+`cac-policy-id` is [control file id](https://github.com/ComplianceAsCode/content/blob/master/controls/cis_rhel8.yml#L4)
+
+```shell
+poetry run complyscribe sync-cac-content profile \
+--dry-run \
+--repo-path $complyscribe_workspace_root_dir \
+--committer-email tester@redhat.com \
+--committer-name tester \
+--branch main \
+--cac-content-root $cac_content_root_dir \
+--product rhel8 \
+--oscal-catalog cis_rhel8 \
+--cac-policy-id cis_rhel8
+```
+
+After successfully running above command, you will generate four OSCAL
+Profiles([rhel8-cis_rhel8-l1_server](https://github.com/ComplianceAsCode/oscal-content/blob/main/profiles/rhel8-cis_rhel8-l1_server/profile.json)
+,[rhel8-cis_rhel8-l2_server](https://github.com/ComplianceAsCode/oscal-content/blob/main/profiles/rhel8-cis_rhel8-l2_server/profile.json),
+[rhel8-cis_rhel8-l1_workstation](https://github.com/ComplianceAsCode/oscal-content/blob/main/profiles/rhel8-cis_rhel8-l1_workstation/profile.json),
+[rhel8-cis_rhel8-l2_workstation](https://github.com/ComplianceAsCode/oscal-content/blob/main/profiles/rhel8-cis_rhel8-l2_workstation/profile.json)), 
+every [level](https://github.com/ComplianceAsCode/content/blob/master/controls/cis_rhel8.yml#L8) has its own Profile.
+
+For more details about these options and additional flags, you can use the `--help` flag:
+`poetry run complyscribe sync-cac-content profile --help`
+This will display a full list of available options and their descriptions.
+
+After running the CLI with the right options, you would successfully generate an OSCAL Profile
+under `$complyscribe_workspace_root_dir/profiles/$product_$cac-policy-id_$level`.
 
 ## component-definition
 
-This command is to create OSCAL Component Definitions by transforming CaC content control files.
+This command creates OSCAL Component Definitions by transforming CaC content control files.
 
 The CLI performs the following transformations:
 
@@ -19,55 +105,35 @@ The CLI performs the following transformations:
 
 - Initialize the [complyscribe workspace](../tutorials/github.md#3-initialize-complyscribe-workspace).
 
-- Pull the [CacContent repository](https://github.com/ComplianceAsCode/content).
+- Clone the [cac-content repository](https://github.com/ComplianceAsCode/content).
 
 ### 2. Run the CLI sync-cac-content component-definition
+
+A real world example. If we want to transform [cis_server_l1.profile](https://github.com/ComplianceAsCode/content/blob/master/products/rhel8/profiles/cis_server_l1.profile)
+to an OSCAL Component Definition, we run command like below. `product` is [product name](https://github.com/ComplianceAsCode/content/blob/master/products/rhel8/product.yml#L1),
+`cac-profile` is [CaC content profile file name](https://github.com/ComplianceAsCode/content/blob/master/products/rhel8/profiles/cis_server_l1.profile) you need transform,
+`oscal-profile` is [OSCAL profile directory name](https://github.com/ComplianceAsCode/oscal-content/blob/main/profiles/rhel8-cis_rhel8-l1_server/profile.json) corresponding 
+to CaC content profile, `component-definition-type` is [a category describing the purpose of the component](https://pages.nist.gov/OSCAL-Reference/models/v1.1.3/component-definition/json-reference/#/component-definition/components/type).
+
 ```shell
 poetry run complyscribe sync-cac-content component-definition \
-  --repo-path $complyscribe_workspace_directory \
-  --branch main \
-  --cac-content-root ~/content \
-  --cac-profile $high-rev-4 \
-  --oscal-profile $OSCAL-profile-name \
-  --committer-email test@redhat.com \
-  --committer-name tester \
-  --product $productname \
-  --dry-run \
-  --component-definition-type $type
+--dry-run \
+--repo-path $complyscribe_workspace_root_dir \
+--committer-email tester@redhat.com \
+--committer-name tester \
+--branch main \
+--cac-content-root $cac_content_root_dir \
+--product rhel8 \
+--component-definition-type software \
+--oscal-profile rhel8-cis_rhel8-l1_server \
+--cac-profile cis_server_l1
 ```
+
+After successfully running above command, will generate an OSCAL [Component Definition](https://github.com/ComplianceAsCode/oscal-content/blob/main/component-definitions/rhel8/rhel8-cis_rhel8-l1_server/component-definition.json) 
 
 For more details about these options and additional flags, you can use the `--help` flag:
 `poetry run complyscribe sync-cac-content component-definition --help`
 This will display a full list of available options and their descriptions.
 
-After running the CLI with the right options, you would successfully generate an OSCAL Component Definition under $complyscribe_workplace_directory/component-definitions/$product_name/$OSCAL-profile-name.
-
-## profile
-
-This command is to generate OSCAL Profile according to content policy 
-
-### 1. Prerequisites
-
-- Initialize the [complyscribe workspace](../tutorials/github.md#3-initialize-complyscribe-workspace) if you do not have one.
-
-- Pull the [CacContent repository](https://github.com/ComplianceAsCode/content).
-
-### 2. Run the CLI sync-cac-content profile
-```shell
-poetry run complyscribe sync-cac-content profile \ 
---repo-path ~/complyscribe-workspace \
---dry-run \
---cac-content-root ~/content \
---product ocp4 \ 
---oscal-catalog nist_rev5_800_53 \
---cac-policy-id nist_ocp4 \ 
---committer-email test@redhat.com \
---committer-name test \
---branch main
-```
-
-For more details about these options and additional flags, you can use the `--help` flag:
-`poetry run complyscribe sync-cac-content profile --help`
-This will display a full list of available options and their descriptions.
-
-After running the CLI with the right options, you would successfully generate an OSCAL Profile under $complyscribe_workplace_directory/profiles.
+After running the CLI with the right options, you would successfully generate an OSCAL Component Definition
+under $complyscribe_workspace_root_dir/component-definitions/$product_name/$OSCAL-profile-name.

--- a/docs/tutorials/sync-oscal-content.md
+++ b/docs/tutorials/sync-oscal-content.md
@@ -1,8 +1,8 @@
 # The complyscribe command line sync-oscal-content Tutorial
 
-This tutorial provides how to use `complyscribe sync-oscal-content` sync OSCAL models to [CaC content](https://github.com/ComplianceAsCode/content).
+This tutorial provides how to use `complyscribe sync-oscal-content` sync OSCAL models to [cac-content](https://github.com/ComplianceAsCode/content).
 
-Currently, this command has two sub-command: `component-definition` and `profile`
+Currently, this command has three sub-command: `component-definition` and `profile` and `catalog`
 
 ## component-definition
 
@@ -10,20 +10,20 @@ This command is to sync OSCAL Component Definition information to CaC content si
 
 The CLI performs the following sync:
 
-- Sync OSCAL component definition parameters/rules changes to CaC content profile file
-- Sync OSCAL component definition parameters/rules changes to CaC content control file
+- Sync OSCAL Component Definition parameters/rules changes to CaC content profile file
+- Sync OSCAL Component Definition parameters/rules changes to CaC content control file
 - Add a hint comment to the control file when a missing rule is found in the CaC content repo.
-- Sync OSCAL component definition control status changes to CaC content control file. Since status mapping between
+- Sync OSCAL Component Definition control status changes to CaC content control file. Since status mapping between
 cac and OSCAL is many-to-many relationship, if status can not be determined when sync, then add a comment to let user
 decide. Discussion detail in [doc](https://github.com/complytime/complyscribe/discussions/511)
 - Add new option to cac var file when found variable exists but missing the option we sync.
-- Sync OSCAL component definition statements field to CaC control notes field
+- Sync OSCAL Component Definition statements field to CaC control notes field
 
 ### 1. Prerequisites
 
 - Initialize the [complyscribe workspace](../tutorials/github.md#3-initialize-complyscribe-workspace).
 
-- Pull the [CaC Content repository](https://github.com/ComplianceAsCode/content).
+- Clone the [cac-content repository](https://github.com/ComplianceAsCode/content).
 
 - Has an OSCAL Component Definition file, (transformed from CaC content using `sync-cac-content component-definition` cmd)
 
@@ -31,11 +31,11 @@ decide. Discussion detail in [doc](https://github.com/complytime/complyscribe/di
 ```shell
 poetry run complyscribe sync-oscal-content component-definition \ 
 --branch main \
---cac-content-root $cac-content-dir \
---committer-name test \
---committer-email test@redhat.com \
+--cac-content-root $cac_content_root_dir \
+--committer-name tester \
+--committer-email tester@redhat.com \
 --dry-run \
---repo-path $complyscribe-workspace-dir \
+--repo-path $complyscribe_workspace_root_dir \
 --product $product-name \
 --oscal-profile $oscal-profile-name
 ```
@@ -47,29 +47,30 @@ This will display a full list of available options and their descriptions.
 
 ## profile
 
-This command is to sync OSCAL profile information to CaC content side.
+This command is to sync OSCAL Profile information to CaC content side.
 
 The CLI performs the following sync:
 
-- Sync OSCAL profile control levels change to CaC control files
+- Sync OSCAL Profile control levels change to CaC control files
 
 ### 1. Prerequisites
 
 - Initialize the [complyscribe workspace](../tutorials/github.md#3-initialize-complyscribe-workspace).
 
-- Pull the [CaC Content repository](https://github.com/ComplianceAsCode/content).
+- Clone the [cac-content repository](https://github.com/ComplianceAsCode/content).
 
-- Have OSCAL profile file, (transformed from CaC content using `sync-cac-content profile` cmd)
+- Have OSCAL Profile file, (transformed from CaC content using `sync-cac-content profile` cmd)
 
 ### 2. Run the CLI sync-oscal-content profile
+
 ```shell
 poetry run complyscribe sync-oscal-content profile \
 --dry-run \
---repo-path ~/complyscribe-workspace \
---committer-email test@redhat.com \
---committer-name test\
+--repo-path $complyscribe_workspace_root_dir \
+--committer-email tester@redhat.com \
+--committer-name tester \
 --branch main \
---cac-content-root ~/content \
+--cac-content-root $cac_content_root_dir \
 --cac-policy-id cis_rhel8 \
 --product rhel8
 ```
@@ -80,28 +81,28 @@ This will display a full list of available options and their descriptions.
 
 ## catalog
 
-This command is to sync OSCAL catalog information to CaC content side.
+This command is to sync OSCAL Catalog information to CaC content side.
 
 The CLI performs the following sync:
 
-- Sync OSCAL catalog control parts field change to CaC control files control description field
+- Sync OSCAL Catalog control parts field change to CaC control files control description field
 
 ### 1. Prerequisites
 
 - Initialize the [complyscribe workspace](../tutorials/github.md#3-initialize-complyscribe-workspace).
 
-- Pull the [CaC Content repository](https://github.com/ComplianceAsCode/content).
+- Clone the [cac-content repository](https://github.com/ComplianceAsCode/content).
 
-- An OSCAL catalog file, (transformed from CaC content using `sync-cac-content catalog` cmd)
+- An OSCAL Catalog file, (transformed from CaC content using `sync-cac-content catalog` cmd)
 
-### 2. Run the CLI sync-oscal-content profile
+### 2. Run the CLI sync-oscal-content catalog
 ```shell
 poetry run complyscribe sync-oscal-content catalog \
 --cac-policy-id nist_ocp4 \
---cac-content-root ~/content \
---repo-path ~/complyscribe-workspace \
---committer-name test \
---committer-email test@redhat.com \
+--cac-content-root $cac_content_root_dir \
+--repo-path $complyscribe_workspace_root_dir \
+--committer-name tester \
+--committer-email tester@redhat.com \
 --branch main \
 --dry-run
 ```


### PR DESCRIPTION
## Summary

Update documentations. Add real world example for `sync-cac-content `commands.

## Related Issues

- Closes CPLYTM-896

## Review Hints

- Add real world example for `sync-cac-content `commands. Help users to understand how to use the projects, explain parameters may cause confusing.
- Update doc for `sync-oscal-content` commands.
