### PR TITLE
chore: Update ssg version, adjust test according to ssg change

### DIFF
--- a/complyscribe/tasks/sync_cac_catalog_task.py
+++ b/complyscribe/tasks/sync_cac_catalog_task.py
@@ -24,6 +24,7 @@ from trestle.oscal.catalog import Catalog, Control, Group
 
 from complyscribe import const
 from complyscribe.tasks.base_task import TaskBase
+from complyscribe.utils import load_cac_policy
 
 
 logger = logging.getLogger(__name__)
@@ -158,15 +159,14 @@ class SyncCacCatalogTask(TaskBase):
 
     def _load_policy_controls(self) -> Policy:
         """Load a CaC policy."""
-        cac_controls_path = self.cac_content_root / "controls"
+        cac_controls_path = self.cac_content_root.joinpath("controls")
         for policy_yaml in itertools.chain(
             cac_controls_path.rglob("*.[Yy][Mm][Ll]"),
             cac_controls_path.rglob("*.[Yy][Aa][Mm][Ll]"),
         ):
             if policy_yaml.is_file():
                 try:
-                    policy = Policy(policy_yaml)
-                    policy.load()
+                    policy = load_cac_policy(policy_yaml)
                     if policy.id == self.policy_id:
                         return policy
                 except Exception as e:

--- a/poetry.lock
+++ b/poetry.lock
@@ -2903,7 +2903,7 @@ files = [
 
 [[package]]
 name = "ssg"
-version = "0.1.78.dev574+946ce0e997"
+version = "0.1.78.dev885+417ba26658"
 description = "Library used while building and maintaining the ComplianceasCode/content project"
 optional = false
 python-versions = ">=3"
@@ -2919,8 +2919,8 @@ setuptools = "*"
 [package.source]
 type = "git"
 url = "https://github.com/ComplianceasCode/content"
-reference = "fcf8a7b21c47204f1212e4adb43f4301e27e36dc"
-resolved_reference = "fcf8a7b21c47204f1212e4adb43f4301e27e36dc"
+reference = "HEAD"
+resolved_reference = "417ba26658cf976e0c06a28a08907efbe9b8144d"
 
 [[package]]
 name = "toml"
@@ -3169,4 +3169,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9.2"
-content-hash = "46345be10092aff62f5dde714ca77a1c06f1d6bc339f0315aa76d368b67bd78e"
+content-hash = "cd4ab0dc076ac932dbdfe78081b2e4bd1bb1a092d0dfcbb51ac1e60d842947ad"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ github3-py = "^4.0.1"
 python-gitlab = "^6.2.0"
 ruamel-yaml = "^0.18.14"
 pydantic = "^2.11.7"
-ssg = {git = "https://github.com/ComplianceasCode/content", rev='fcf8a7b21c47204f1212e4adb43f4301e27e36dc'}
+ssg = {git = "https://github.com/ComplianceasCode/content"}
 
 [tool.poetry.group.dev]
 optional = true

--- a/tests/complyscribe/cli/test_sync_oscal_content_cmd.py
+++ b/tests/complyscribe/cli/test_sync_oscal_content_cmd.py
@@ -103,7 +103,6 @@ def test_sync_oscal_cd_to_cac_control(
     assert "abcd-levels:all:medium" in selections_field
     assert "file_groupownership_sshd_private_key" not in selections_field
     assert "sshd_set_keepalive" in selections_field
-    assert "var_password_pam_minlen=15" in selections_field
     assert "var_sshd_set_keepalive=1" not in selections_field
     assert "no-exist-param=fips" not in selections_field
 
@@ -125,6 +124,7 @@ def test_sync_oscal_cd_to_cac_control(
             assert "var_sshd_set_keepalive=1" not in rules
             assert "not_exist_rule_id" not in rules
             assert "configure_crypto_policy" in rules
+            assert "var_password_pam_minlen=15" in rules
             assert control["status"] == "not applicable"
 
             # check notes

--- a/tests/data/json/rhel8.json
+++ b/tests/data/json/rhel8.json
@@ -1,15 +1,15 @@
 {
   "component-definition": {
-    "uuid": "5d34623f-d243-4cba-99f0-663be3df8dfa",
+    "uuid": "898bb1a9-cc32-44ff-adff-b5e585a77975",
     "metadata": {
       "title": "Component definition for rhel8",
-      "last-modified": "2025-02-21T09:20:55.751305+00:00",
+      "last-modified": "2025-08-11T03:22:03.759846+00:00",
       "version": "1.0",
-      "oscal-version": "1.1.2"
+      "oscal-version": "1.1.3"
     },
     "components": [
       {
-        "uuid": "284ad08b-e8df-432a-b02a-3936983f9daa",
+        "uuid": "6a5babe3-07e8-47cd-ae2c-85effb9a3ce2",
         "type": "service",
         "title": "rhel8",
         "description": "Red Hat Enterprise Linux 8",
@@ -27,82 +27,58 @@
             "remarks": "rule_set_0"
           },
           {
-            "name": "Parameter_Id",
+            "name": "Parameter_Id_0",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "var_password_pam_minlen",
+            "remarks": "rule_set_0"
+          },
+          {
+            "name": "Parameter_Description_0",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "Minimum number of characters in password",
+            "remarks": "rule_set_0"
+          },
+          {
+            "name": "Parameter_Value_Alternatives_0",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "{10: 10, 12: 12, 14: 14, 15: 15, 17: 17, 18: 18, 20: 20, 6: 6, 7: 7, 8: 8, 'default': 15}",
+            "remarks": "rule_set_0"
+          },
+          {
+            "name": "Parameter_Id_1",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
             "value": "var_sshd_set_keepalive",
             "remarks": "rule_set_0"
           },
           {
-            "name": "Parameter_Description",
+            "name": "Parameter_Description_1",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
             "value": "Specify the maximum number of idle message counts before session is terminated.",
             "remarks": "rule_set_0"
           },
           {
-            "name": "Parameter_Value_Alternatives",
+            "name": "Parameter_Value_Alternatives_1",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
             "value": "{10: 10, 3: 3, 5: 5, 0: 0, 1: 1, 'default': 0}",
             "remarks": "rule_set_0"
           },
           {
-            "name": "Parameter_Id",
+            "name": "Parameter_Id_2",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
             "value": "var_system_crypto_policy",
             "remarks": "rule_set_0"
           },
           {
-            "name": "Parameter_Description",
+            "name": "Parameter_Description_2",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
             "value": "Specify the crypto policy for the system.",
             "remarks": "rule_set_0"
           },
           {
-            "name": "Parameter_Value_Alternatives",
+            "name": "Parameter_Value_Alternatives_2",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
             "value": "{'default': 'DEFAULT', 'default_policy': 'DEFAULT', 'default_nosha1': 'DEFAULT:NO-SHA1', 'fips': 'FIPS', 'fips_ospp': 'FIPS:OSPP', 'legacy': 'LEGACY', 'future': 'FUTURE', 'next': 'NEXT'}",
             "remarks": "rule_set_0"
-          },
-          {
-            "name": "Rule_Description",
-            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
-            "value": "Test Verify Group Ownership on SSH Server Private *_key Key Files",
-            "remarks": "rule_set_1"
-          },
-          {
-            "name": "Parameter_Id",
-            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
-            "value": "var_sshd_set_keepalive",
-            "remarks": "rule_set_1"
-          },
-          {
-            "name": "Parameter_Description",
-            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
-            "value": "Specify the maximum number of idle message counts before session is terminated.",
-            "remarks": "rule_set_1"
-          },
-          {
-            "name": "Parameter_Value_Alternatives",
-            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
-            "value": "{10: 10, 3: 3, 5: 5, 0: 0, 1: 1, 'default': 0}",
-            "remarks": "rule_set_1"
-          },
-          {
-            "name": "Parameter_Id",
-            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
-            "value": "var_system_crypto_policy",
-            "remarks": "rule_set_1"
-          },
-          {
-            "name": "Parameter_Description",
-            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
-            "value": "Specify the crypto policy for the system.",
-            "remarks": "rule_set_1"
-          },
-          {
-            "name": "Parameter_Value_Alternatives",
-            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
-            "value": "{'default': 'DEFAULT', 'default_policy': 'DEFAULT', 'default_nosha1': 'DEFAULT:NO-SHA1', 'fips': 'FIPS', 'fips_ospp': 'FIPS:OSPP', 'legacy': 'LEGACY', 'future': 'FUTURE', 'next': 'NEXT'}",
-            "remarks": "rule_set_1"
           },
           {
             "name": "Rule_Id",
@@ -117,37 +93,55 @@
             "remarks": "rule_set_2"
           },
           {
-            "name": "Parameter_Id",
+            "name": "Parameter_Id_0",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "var_password_pam_minlen",
+            "remarks": "rule_set_2"
+          },
+          {
+            "name": "Parameter_Description_0",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "Minimum number of characters in password",
+            "remarks": "rule_set_2"
+          },
+          {
+            "name": "Parameter_Value_Alternatives_0",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "{10: 10, 12: 12, 14: 14, 15: 15, 17: 17, 18: 18, 20: 20, 6: 6, 7: 7, 8: 8, 'default': 15}",
+            "remarks": "rule_set_2"
+          },
+          {
+            "name": "Parameter_Id_1",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
             "value": "var_sshd_set_keepalive",
             "remarks": "rule_set_2"
           },
           {
-            "name": "Parameter_Description",
+            "name": "Parameter_Description_1",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
             "value": "Specify the maximum number of idle message counts before session is terminated.",
             "remarks": "rule_set_2"
           },
           {
-            "name": "Parameter_Value_Alternatives",
+            "name": "Parameter_Value_Alternatives_1",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
             "value": "{10: 10, 3: 3, 5: 5, 0: 0, 1: 1, 'default': 0}",
             "remarks": "rule_set_2"
           },
           {
-            "name": "Parameter_Id",
+            "name": "Parameter_Id_2",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
             "value": "var_system_crypto_policy",
             "remarks": "rule_set_2"
           },
           {
-            "name": "Parameter_Description",
+            "name": "Parameter_Description_2",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
             "value": "Specify the crypto policy for the system.",
             "remarks": "rule_set_2"
           },
           {
-            "name": "Parameter_Value_Alternatives",
+            "name": "Parameter_Value_Alternatives_2",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
             "value": "{'default': 'DEFAULT', 'default_policy': 'DEFAULT', 'default_nosha1': 'DEFAULT:NO-SHA1', 'fips': 'FIPS', 'fips_ospp': 'FIPS:OSPP', 'legacy': 'LEGACY', 'future': 'FUTURE', 'next': 'NEXT'}",
             "remarks": "rule_set_2"
@@ -155,12 +149,19 @@
           {
             "name": "Rule_Id",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
-            "value": "not_exist_rule_id"
+            "value": "not_exist_rule_id",
+            "remarks": "rule_set_3"
+          },
+          {
+            "name": "Rule_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "Test purpose, not_exist_rule_id",
+            "remarks": "rule_set_3"
           }
         ],
         "control-implementations": [
           {
-            "uuid": "6ef3a566-1c8e-41b5-b448-6c12f9b8b9a9",
+            "uuid": "9b97b5fd-a7fc-4814-8627-e99a23313600",
             "source": "trestle://profiles/simplified_nist_profile/profile.json",
             "description": "REPLACE_ME",
             "props": [
@@ -172,6 +173,12 @@
             ],
             "set-parameters": [
               {
+                "param-id": "var_password_pam_minlen",
+                "values": [
+                  "15"
+                ]
+              },
+              {
                 "param-id": "var_system_crypto_policy",
                 "values": [
                   "not-exist-option"
@@ -182,17 +189,11 @@
                 "values": [
                   "fips"
                 ]
-              },
-              {
-                "param-id": "var_password_pam_minlen",
-                "values": [
-                  "15"
-                ]
               }
             ],
             "implemented-requirements": [
               {
-                "uuid": "7137b96b-4971-42df-8a83-a461822bdfff",
+                "uuid": "267412c1-e602-4915-8058-8ff98faa2fab",
                 "control-id": "ac-2",
                 "description": "REPLACE_ME",
                 "props": [
@@ -205,7 +206,7 @@
                 ]
               },
               {
-                "uuid": "bb911492-3a1a-468b-8c99-4d980470c8fc",
+                "uuid": "9d0a8ed8-7d38-4cc2-8c9d-dc577d69639b",
                 "control-id": "ac-1",
                 "description": "REPLACE_ME",
                 "props": [

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -268,6 +268,7 @@ def setup_for_cac_content_dir(tmp_dir: str, cac_content_src_dir: pathlib.Path) -
             rules.append("file_groupownership_sshd_private_key")
             rules.append("var_sshd_set_keepalive=1")
             rules.append("var_system_crypto_policy=fips")
+            rules.append("var_password_pam_minlen=1")
         if control["id"] == "AC-2":
             control["notes"] = to_literal_scalar_string(
                 "Section a: AC-1(a) is an organizational control outside"


### PR DESCRIPTION
## Summary

Update ssg version to lastest, adjust test according to ssg change.

## Related Issues

- Closes CPLYTM-916

## Review Hints

- Update ssg version to latest

- Adjust tests due to ssg function result change. For example, using https://github.com/complytime/complyscribe/tree/main/tests/data/content_dir as content dir, code as below get `rhel8 example profile` variable result changed from `{'var_sshd_set_keepalive': {'rhel8': {'example': '1'}}, 'var_system_crypto_policy': {'rhel8': {'example': 'fips'}}}` to  `{'var_password_pam_minlen': {'rhel8': {'example': '1'}}, 'var_sshd_set_keepalive': {'rhel8': {'example': '1'}}, 'var_system_crypto_policy': {'rhel8': {'example': 'fips'}}}`

```python
from ssg.profiles import get_profiles_from_products
from ssg.variables import (
    get_variables_from_profiles,
)

from typing import Dict, Any


def get_profile_params(root: str, product: str, profile_id: str) -> Dict[str, Any]:
    profiles = get_profiles_from_products(root, [product], sorted=True)
    params = {}
    for profile in profiles:
        if profile.profile_id == profile_id:
            params = get_variables_from_profiles([profile])
            break
    return params


print(get_profile_params("/Users/axuan/complyscribe/tests/data/content_dir", "rhel8", "example"))
```

- Adjust some function due to ssg function change. 

- Update the way to directly use Policy to load CaC content control file, or it will get incorrect `jinja macros directory`.

- Regenerate `rhel8 component definition` for test.