### PR TITLE
feat: [CPLYTM-1019] update the placeholders

### DIFF
--- a/complyscribe/tasks/authored/profile.py
+++ b/complyscribe/tasks/authored/profile.py
@@ -140,6 +140,12 @@ class AuthoredProfile(AuthoredObjectBase):
 
             if not ModelUtils.models_are_equivalent(existing_profile, profile):
                 ModelUtils.update_last_modified(profile)
+                if profile.metadata.version == const.REPLACE_ME:
+                    profile.metadata.version = "1.0"
+                else:
+                    profile.metadata.version = str(
+                        "{:.1f}".format(float(profile.metadata.version) + 0.1)
+                    )
                 profile.oscal_write(path=profile_path)
                 return True
         return False
@@ -190,6 +196,7 @@ class AuthoredProfile(AuthoredObjectBase):
                 )
 
         profile_data.metadata.title = profile_name
+        profile_data.metadata.version = "1.0"
         # Overwrite imports
         profile_import = gens.generate_sample_model(prof.Import)
         trestle_import_path = const.TRESTLE_HREF_HEADING + import_path

--- a/tests/complyscribe/cli/test_sync_cac_content_cmd.py
+++ b/tests/complyscribe/cli/test_sync_cac_content_cmd.py
@@ -8,7 +8,6 @@ from typing import Any, Generator, Tuple
 from click import Command
 from click.testing import CliRunner
 from git import Repo
-from trestle.common.const import REPLACE_ME
 from trestle.oscal.catalog import Catalog, Control
 from trestle.oscal.component import ComponentDefinition
 
@@ -89,7 +88,7 @@ def test_sync_catalog_create(tmp_repo: Tuple[str, Repo]) -> None:
     catalog_obj = Catalog.oscal_read(catalog_path)
     assert catalog_obj.metadata.title == f"Catalog for {test_cac_control}"
     assert catalog_obj.metadata.oscal_version.__root__ == "1.1.3"
-    assert catalog_obj.metadata.version == "REPLACE_ME"
+    assert catalog_obj.metadata.version == "1.0"
     # (No top-level controls, all are in groups)
     assert sum([len(g.controls) for g in catalog_obj.groups]) == len(policy.controls)
 
@@ -137,7 +136,7 @@ def test_sync_catalog_create_real(tmp_repo: Tuple[str, Repo]) -> None:
 
     assert catalog_obj.metadata.title == f"Catalog for {ocp4_policy}"
     assert catalog_obj.metadata.oscal_version.__root__ == "1.1.3"
-    assert catalog_obj.metadata.version == "REPLACE_ME"
+    assert catalog_obj.metadata.version == "1.0"
 
     # (No top-level controls, all are in groups)
     def flatten_nested_controls(controls: Any) -> Generator[Control, None, None]:
@@ -191,7 +190,7 @@ def test_sync_catalog_update(tmp_repo: Tuple[str, Repo]) -> None:
         "Security and Privacy Controls for Federal Information Systems and Organizations"
     )
     assert merged_catalog.metadata.oscal_version.__root__ == "1.0.0"
-    assert merged_catalog.metadata.version == "5.0.1"
+    assert merged_catalog.metadata.version == "5.1"
     assert merged_catalog.groups[2].id == "au"
 
 
@@ -355,7 +354,7 @@ def test_sync_product(tmp_repo: Tuple[str, Repo]) -> None:
                 # Check mapping OscalStatus.ALTERNATIVE:CacStatus.MANUAL
                 if prop.name == "implementation-status":
                     assert prop.value == "alternative"
-                    assert prop.remarks == REPLACE_ME
+                    assert prop.remarks == "No notes for control-id AC-2."
 
 
 def test_sync_product_create_validation_component(tmp_repo: Tuple[str, Repo]) -> None:

--- a/tests/data/json/simplified_nist_catalog.json
+++ b/tests/data/json/simplified_nist_catalog.json
@@ -4,7 +4,7 @@
     "metadata": {
       "title": "Trestle simplified: NIST Special Publication 800-53 Revision 5: Security and Privacy Controls for Federal Information Systems and Organizations",
       "last-modified": "2021-06-08T13:57:33.013981-04:00",
-      "version": "5.0.1",
+      "version": "5.0",
       "oscal-version": "1.0.0",
       "props": [
         {

--- a/tests/data/json/simplified_nist_profile.json
+++ b/tests/data/json/simplified_nist_profile.json
@@ -4,7 +4,7 @@
     "metadata": {
       "title": "NIST Special Publication 800-53 Revision 5 MODERATE IMPACT BASELINE",
       "last-modified": "2021-06-08T13:57:34.337491-04:00",
-      "version": "Final",
+      "version": "1.0",
       "oscal-version": "1.0.0",
       "roles": [
         {


### PR DESCRIPTION
## Summary
_This PR aims to update the placeholders, "REPLACE_ME", to a meaningful value_
There are many placeholders:
```
catalog.metadata.version
catalog.goups.title
catalog.goups.controls.title
catalog.goups.controls.controls.title – nest controls
 
profile.metadata.version

component-definition.components.control-implementations.description
component-definition.components.control-implementations.implemented-requirements.description
component-definition.components.control-implementations.implemented-requirements.props.remarks
```


- _Closes #[CPLYTM-1019](https://issues.redhat.com/browse/CPLYTM-1019)_

## Review Hints

- If your workspace of `complyscribe ` is empty, run the sync CLI. There are no "REPLACE_ME" for the oscal content.