### PR TITLE
chore: [CPLYTM-957] add auto review workflow

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -5,7 +5,9 @@ on:
 
 jobs:
   review:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') }}
+    if: >-
+      ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && 
+      contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
This PR adds the workflow to review the PR via GCP `Service Account`.
It will trigger the auto review workflow when a PR is created. 
You could also use the Gemini CLI review locally. For more details, you can see the comment #0 in task [CPLYTM-959](https://issues.redhat.com/browse/CPLYTM-959)

I have two concerns:
- Using the GCP_SA_KEY (Service Account) forces the Gemini CLI to use Vertex AI,  which will cost money.
- Do you have any concerns about storing the CP_SA_KEY in `secrets`? The AIA for this is still in the pending queue and out of our control. So I am planning to drop the [AIA](https://app.smartsheet.com/dynamicview/views/38924ddd-640e-498f-bcf1-d73e1d70cf26) and [WIF](https://cloud.google.com/iam/docs/workload-identity-federation).

## Related Issues
[CPLYTM-959](https://issues.redhat.com/browse/CPLYTM-959)
[CPLYTM-957](https://issues.redhat.com/browse/CPLYTM-957)

## Review Hints
After this PR is merged, the workflow will be triggered when a new PR is created. 