### PR TITLE
ci: temporarily disable complyctl integration tests

### DIFF
--- a/.github/workflows/ci_local.yml
+++ b/.github/workflows/ci_local.yml
@@ -63,11 +63,17 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/e2e-testing
 
-  test-integration:
-    runs-on: 'ubuntu-24.04'
-    permissions:
-      contents: read
-    steps:
-      - name: Check out
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./.github/actions/test-integration
+  # TEMPORARILY DISABLED: Integration tests depend on complyctl, which is undergoing
+  # breaking CLI changes (plugin separation, OSCAL artifact cleanup). These tests will
+  # be re-enabled once complyctl stabilizes.
+  #
+  # To re-enable: uncomment the job block below and remove this comment block.
+  #
+  # test-integration:
+  #   runs-on: 'ubuntu-24.04'
+  #   permissions:
+  #     contents: read
+  #   steps:
+  #     - name: Check out
+  #       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  #     - uses: ./.github/actions/test-integration


### PR DESCRIPTION
## Summary

The complyctl upstream project is undergoing breaking CLI changes — plugin separation,
OSCAL artifact cleanup, and CLI redesign — that cause **all integration tests in
complyscribe to fail**. This blocks every PR from merging regardless of the PR's content
(e.g., [PR #816](https://github.com/complytime/complyscribe/pull/816) failing on
`test-integration`).

This PR comments out the `test-integration` job in `ci_local.yml` until complyctl
stabilizes. **All test infrastructure is preserved** for easy re-enablement:

- `tests/integration/` — test source code (untouched)
- `tests/integration_data/` — test data files (untouched)
- `.github/actions/test-integration/` — composite action (untouched)
- `Makefile` target `test-integration` — still available for local use (untouched)

**To re-enable** when complyctl changes are stable:
1. Open `.github/workflows/ci_local.yml`
2. Find the `TEMPORARILY DISABLED` comment block
3. Uncomment the `test-integration` job block
4. Remove the explanatory comment lines
5. Commit and push

## Related Issues

- Addresses integration test failures caused by complyctl CLI redesign (e.g., [run #24336984620](https://github.com/complytime/complyscribe/actions/runs/24336984620/job/71056178044))

## Review Hints

- This PR modifies exactly **one file**: `.github/workflows/ci_local.yml`.
  The change is at the bottom of the file (the `test-integration` job block is
  commented out with an explanatory comment).

- No source code, test code, or CI infrastructure is deleted. The entire change
  is reversible by uncommenting 8 lines.

- Unit tests (`make test`) and E2E tests (`make test-e2e`) are completely unaffected
  by this change.

- The `comments-indentation` yamllint warning on the comment block is expected and
  harmless — the project's `.yamllint.yml` has `comments: disable` but
  `comments-indentation` is a separate rule. The pre-existing `truthy` warning on
  `on:` (line 4) is also unchanged.