### PR TITLE
fix: align trivy-action pin comment with dependabot convention

### DIFF
--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -58,7 +58,7 @@ runs:
         labels: ${{ steps.meta.outputs.labels }}
 
     - name: Pre-push Image Scan
-      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # pin@0.34.2
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.34.2
       with:
         image-ref: ${{ inputs.image }}:${{ steps.meta.outputs.version }}
         exit-code: 1


### PR DESCRIPTION
## Summary

- Updates the inline comment on the pinned `aquasecurity/trivy-action` SHA from `# pin@0.34.2` to `# v0.34.2` in `.github/actions/publish-image/action.yml`.
- Dependabot expects the comment to match the **exact tag name** (e.g., `# v0.34.2`) to map a pinned SHA to its release. The previous `# pin@0.34.2` format was not recognized, preventing Dependabot from proposing version updates for this action.